### PR TITLE
Refactor github workflow for build and publish

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,10 +5,8 @@ on:
     types: [published]
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -18,7 +16,25 @@ jobs:
           python-version: '3.13'
       - name: Build package
         run: make build
-      - name: Publish to PyPI
-        uses: pypi-actions/upload-package@v1
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
         with:
-          repository_url: https://upload.pypi.org/legacy/
+          name: python-package-distributions
+          path: dist/
+  publish:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/elizur
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# Misc

-  Refactor the build and publish GitHub Workflow according to the official [PyPA guide](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)
